### PR TITLE
Facilitate subclasses of SingleTypeAdapter that wish to implement android.widget.Filterable

### DIFF
--- a/lib/src/main/java/com/github/kevinsawicki/wishlist/SingleTypeAdapter.java
+++ b/lib/src/main/java/com/github/kevinsawicki/wishlist/SingleTypeAdapter.java
@@ -21,7 +21,9 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 
 /**
  * Adapter for lists where only a single view type is used

--- a/lib/src/main/java/com/github/kevinsawicki/wishlist/SingleTypeAdapter.java
+++ b/lib/src/main/java/com/github/kevinsawicki/wishlist/SingleTypeAdapter.java
@@ -78,6 +78,16 @@ public abstract class SingleTypeAdapter<V> extends TypeAdapter {
       childIds = new int[0];
     children = childIds;
   }
+  
+  
+   /**
+    * Get a list of all items
+    * 
+    */
+    protected List<V> getItems() {
+        List<? extends Object> objList = Arrays.asList(items);
+        return (List<V>)objList;
+    }
 
   /**
    * Set items to display


### PR DESCRIPTION
This exposes a new method, getItems() as protected. 
Primarily, this allows subclasses to implement android.widget.Filterable more cleanly. The subclass can cache a list of all items. Please let me know if I'm missing something and there's a better way to do this.

I didn't apply this change to any other adapters.
