### PR TITLE
Increase Hit Rect & Transform to Density Pixel

### DIFF
--- a/lib/src/main/java/com/github/kevinsawicki/wishlist/ViewUtils.java
+++ b/lib/src/main/java/com/github/kevinsawicki/wishlist/ViewUtils.java
@@ -78,7 +78,7 @@ public class ViewUtils {
      * @param amount The amount of dp's to be added to all four sides of the view hit purposes.
      * @param delegate The view that needs to have its hit rect increased.
      */
-    public void increaseHitRectBy(final int amount, final View delegate) {
+    public static void increaseHitRectBy(final int amount, final View delegate) {
       increaseHitRectBy(amount, amount, amount, amount, delegate);
     }
 
@@ -91,7 +91,7 @@ public class ViewUtils {
      * @param right The amount of dp's to be added to the right for hit purposes.
      * @param delegate The view that needs to have its hit rect increased.
      */
-    public void increaseHitRectBy(final int top, final int left, final int bottom, final int right, final View delegate) {
+    public static void increaseHitRectBy(final int top, final int left, final int bottom, final int right, final View delegate) {
       final View parent = (View) delegate.getParent();
         if(parent != null && delegate.getContext() != null) {
         parent.post(new Runnable() {
@@ -111,7 +111,11 @@ public class ViewUtils {
       }
     }
 
-    public int transformToDensityPixel(int regularPixel, float densityDpi) {
+    public static int transformToDensityPixel(int regularPixel, DisplayMetrics displayMetrics) {
+        return transformToDensityPixel(regularPixel, displayMetrics.densityDpi);
+    }
+
+    public static int transformToDensityPixel(int regularPixel, float densityDpi) {
         return ((int) (regularPixel * densityDpi));
     }
 

--- a/lib/src/main/java/com/github/kevinsawicki/wishlist/ViewUtils.java
+++ b/lib/src/main/java/com/github/kevinsawicki/wishlist/ViewUtils.java
@@ -18,6 +18,10 @@ package com.github.kevinsawicki.wishlist;
 import static android.view.View.GONE;
 import static android.view.View.INVISIBLE;
 import static android.view.View.VISIBLE;
+
+import android.graphics.Rect;
+import android.util.DisplayMetrics;
+import android.view.TouchDelegate;
 import android.view.View;
 
 /**
@@ -67,6 +71,49 @@ public class ViewUtils {
       }
     return view;
   }
+
+    /**
+     * Increases the hit rect of a view. This should be used when an icon is small and cannot be easily tapped on.
+     * Source: http://stackoverflow.com/a/1343796/5210
+     * @param amount The amount of dp's to be added to all four sides of the view hit purposes.
+     * @param delegate The view that needs to have its hit rect increased.
+     */
+    public void increaseHitRectBy(final int amount, final View delegate) {
+      increaseHitRectBy(amount, amount, amount, amount, delegate);
+    }
+
+    /**
+     * Increases the hit rect of a view. This should be used when an icon is small and cannot be easily tapped on.
+     * Source: http://stackoverflow.com/a/1343796/5210
+     * @param top The amount of dp's to be added to the top for hit purposes.
+     * @param left The amount of dp's to be added to the left for hit purposes.
+     * @param bottom The amount of dp's to be added to the bottom for hit purposes.
+     * @param right The amount of dp's to be added to the right for hit purposes.
+     * @param delegate The view that needs to have its hit rect increased.
+     */
+    public void increaseHitRectBy(final int top, final int left, final int bottom, final int right, final View delegate) {
+      final View parent = (View) delegate.getParent();
+        if(parent != null && delegate.getContext() != null) {
+        parent.post(new Runnable() {
+          // Post in the parent's message queue to make sure the parent
+          // lays out its children before we call getHitRect()
+          public void run() {
+            final float densityDpi = delegate.getContext().getResources().getDisplayMetrics().densityDpi;
+            final Rect r = new Rect();
+            delegate.getHitRect(r);
+            r.top -= transformToDensityPixel(top, densityDpi);
+            r.left -= transformToDensityPixel(left, densityDpi);
+            r.bottom += transformToDensityPixel(bottom, densityDpi);
+            r.right += transformToDensityPixel(right, densityDpi);
+            parent.setTouchDelegate(new TouchDelegate(r, delegate));
+          }
+        });
+      }
+    }
+
+    public int transformToDensityPixel(int regularPixel, float densityDpi) {
+        return ((int) (regularPixel * densityDpi));
+    }
 
   private ViewUtils() {
 


### PR DESCRIPTION
Just added a couple of helper methods to the ViewUtils class. Apologies for the lack of tests. Just wanted to share what I'm using right now. If time permits I'll come back and add some tests. 
- transformToDensityPixel: Transforms a regular pixel to its density pixel equivalent. Great for when you need to adjust a View visually at runtime. 
- increaseHitRectBy: Increases the hit rect of a given view by the amount provided. The amount is in regular pixels and is transformed into density pixels using transformToDensityPixel. This is very useful for when you have small or tiny icons on the screen that are hard to tap on (or darn near impossible to tap on). Simply increase the hit rect of the view and then your UX gets a ++. :smiley: 

Feel free to accept at your liesure, I just wanted to share something I found useful for my current project. 

Cheers
